### PR TITLE
Fix: Bootstrap job Cloud SQL syntax error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
           gcloud run jobs create bootstrap-users-${{ github.run_number }} \
             --image "$IMAGE" \
             --region "$REGION" \
-            --add-cloudsql-instances "$CONN_NAME" \
+            --set-cloudsql-instances "$CONN_NAME" \
             --set-env-vars "SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }},DB_ENGINE=postgres,DB_NAME=${{ secrets.DB_NAME }},DB_USER=${{ secrets.DB_USER }},DB_PASSWORD=${{ secrets.DB_PASSWORD }},DB_HOST=/cloudsql/$CONN_NAME" \
             --command python \
             --args "manage.py,bootstrap" \


### PR DESCRIPTION

## 🐛 Problem
GitHub Actions deploy failing on bootstrap step with error:
`unrecognized arguments: --add-cloudsql-instances`

## 🔧 Solution  
- Change `--add-cloudsql-instances` to `--set-cloudsql-instances`
- This is the correct syntax for `gcloud run jobs` (different from `gcloud run deploy`)

## ✅ Testing
- [x] Syntax verified in gcloud documentation
- [x] Ready for deployment

## 📋 Changes
- One line change in `.github/workflows/deploy.yml`
- Fixes automatic user bootstrap in production

Ready to merge and deploy! 🚀
