### PR TITLE
docs: link CI/CD secrets checklist from READMEs

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -89,11 +89,15 @@ git push origin dev
 make -f makefiles/dev.mk dev-test-real
 ```
 
+Los secretos de CI/CD para dev y prod están documentados en `docs/ci-secrets.md`.
+
 ### Staging/Production
 ```bash
 # Deploy via GitHub Actions (branch: main)
 git push origin main
 ```
+
+Los secretos necesarios para producción están listados en `docs/ci-secrets.md`.
 
 ## Variables de Entorno
 

--- a/README.md
+++ b/README.md
@@ -89,11 +89,15 @@ git push origin dev
 make -f makefiles/dev.mk dev-test-real
 ```
 
+CI/CD secrets for dev/prod are documented in `docs/ci-secrets.md`.
+
 ### Staging/Production
 ```bash
 # Deploy via GitHub Actions (branch: main)
 git push origin main
 ```
+
+CI/CD secrets required for production are listed in `docs/ci-secrets.md`.
 
 ## Environment Variables
 


### PR DESCRIPTION
Add references to docs/ci-secrets.md in both README languages so contributors can configure Actions secrets correctly.